### PR TITLE
Fix peerB event listener message and typos

### DIFF
--- a/webrtc/peerA.js
+++ b/webrtc/peerA.js
@@ -1,39 +1,36 @@
-
- /*
+/*
 //you can specify a STUN server here
-
+ 
 const iceConfiguration = { }
 iceConfiguration.iceServers = [];
 //turn server
 iceConfiguration.iceServers.push({
-                urls: 'turn:my-turn-server.mycompany.com:19403',
-                username: 'optional-username',
-                credentials: 'auth-token'
-            })
+                urls: 'turn:my-turn-server.mycompany.com:19403',
+                username: 'optional-username',
+                credentials: 'auth-token'
+            })
 //stun  server
 iceConfiguration.iceServers.push({
-                urls: 'stun:stun1.l.google.com:19302' 
-            })    
-
+                urls: 'stun:stun1.l.google.com:19302' 
+            })    
+ 
 const localConnection = new RTCPeerConnection(iceConfiguration)
-
-
+ 
+ 
 */
 
-const localConnection = new RTCPeerConnection()
- 
+const localConnection = new RTCPeerConnection();
 
-localConnection.onicecandidate = e =>  {
-console.log(" NEW ice candidnat!! on localconnection reprinting SDP " )
- console.log(JSON.stringify(localConnection.localDescription))
-}
-
+localConnection.onicecandidate = (e) => {
+  console.log(" NEW ice candidate!! on localConnection reprinting SDP ");
+  console.log(JSON.stringify(localConnection.localDescription));
+};
 
 const sendChannel = localConnection.createDataChannel("sendChannel");
- sendChannel.onmessage =e =>  console.log("messsage received!!!"  + e.data )
-   sendChannel.onopen = e => console.log("open!!!!");
-     sendChannel.onclose =e => console.log("closed!!!!!!");
+sendChannel.onmessage = (e) => console.log("message received!!!" + e.data);
+sendChannel.onopen = (e) => console.log("open!!!!");
+sendChannel.onclose = (e) => console.log("closed!!!!!!");
 
-
-localConnection.createOffer().then(o => localConnection.setLocalDescription(o) )
-
+localConnection
+  .createOffer()
+  .then((o) => localConnection.setLocalDescription(o));

--- a/webrtc/peerB.js
+++ b/webrtc/peerB.js
@@ -1,26 +1,24 @@
 //set offer const offer = ...
-const remoteConnection = new RTCPeerConnection()
+const remoteConnection = new RTCPeerConnection();
 
-remoteConnection.onicecandidate = e =>  {
-console.log(" NEW ice candidnat!! on localconnection reprinting SDP " )
- console.log(JSON.stringify(remoteConnection.localDescription) )
-}
+remoteConnection.onicecandidate = (e) => {
+  console.log(" NEW ice candidate!! on remoteConnection reprinting SDP ");
+  console.log(JSON.stringify(remoteConnection.localDescription));
+};
 
- 
-remoteConnection.ondatachannel= e => {
+remoteConnection.ondatachannel = (e) => {
+  const receiveChannel = e.channel;
+  receiveChannel.onmessage = (e) => console.log("message received!!!" + e.data);
+  receiveChannel.onopen = (e) => console.log("open!!!!");
+  receiveChannel.onclose = (e) => console.log("closed!!!!!!");
+  remoteConnection.channel = receiveChannel;
+};
 
-      const receiveChannel = e.channel;
-      receiveChannel.onmessage =e =>  console.log("messsage received!!!"  + e.data )
-      receiveChannel.onopen = e => console.log("open!!!!");
-      receiveChannel.onclose =e => console.log("closed!!!!!!");
-      remoteConnection.channel = receiveChannel;
-
-}
-
-
-remoteConnection.setRemoteDescription(offer).then(a=>console.log("done"))
+remoteConnection.setRemoteDescription(offer).then((a) => console.log("done"));
 
 //create answer
-await remoteConnection.createAnswer().then(a => remoteConnection.setLocalDescription(a)).then(a=>
-console.log(JSON.stringify(remoteConnection.localDescription)))
-//send the anser to the client 
+await remoteConnection
+  .createAnswer()
+  .then((a) => remoteConnection.setLocalDescription(a))
+  .then((a) => console.log(JSON.stringify(remoteConnection.localDescription)));
+//send the answer to the client


### PR DESCRIPTION
Since we are using different variable names for local and remote peer connection, we can also run them in the same browser console, just the ICE candidate logging message needed correction for peerB.