### PR TITLE
Update docker-compose.yml

### DIFF
--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   zookeeper:
     image: zookeeper
@@ -7,11 +6,16 @@ services:
       - 2181:2181
 
   kafka:
+    restart: always
     image: ches/kafka
     hostname: localhost
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: <YOUR_IP_ADDRESS>
-      ZOOKEEPER_IP: <YOUR_IP_ADDRESS>
+      KAFKA_ADVERTISED_HOST_NAME: <KAFKA_CONTAINER_IP_ADDRESS>
+      ZOOKEEPER_IP: <ZOOKEEPER_CONTAINER_IP_ADDRESS>
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      ALLOW_PLAINTEXT_LISTENER: 1
+    
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
I think it's a better fit for universal docker configuration.

- [x] version is not required in docker-compose anymore
- [x] kafka container should be depended on zookeeper
- [x] kafka should restart when it's missing something or the zookeeper made some delay to start
- [x] ALLOW_PLAINTEXT_LISTENER: 1 makes it more explicit considering dev environment
- [x] changed this <YOUR_IP_ADDRESS> to more specific